### PR TITLE
fix(animations): added tag to vue2 lib and fixed anchor

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "axios": "^0.16.2",
     "vue": "^2.3.3",
-    "vue2-google-maps": "git+https://github.com/jeebay/vue-google-maps.git#vue2"
+    "vue2-google-maps": "git+https://github.com/jeebay/vue-google-maps.git#11.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",

--- a/src/components/MapComponent.vue
+++ b/src/components/MapComponent.vue
@@ -100,7 +100,7 @@
             fillOpacity: .9,
             strokeWeight: 0,
             scale: .5,
-            anchor: new google.maps.Point(16,16),
+            anchor: {x: 16, y:16},
 	          rotation: 270
           }
         };


### PR DESCRIPTION
Created tag 11.0.0 for the forked vue2-google-maps library and modified our package.json accordingly. 

Changed `new google.maps.Point(16, 16)` to plain object `{x: 16, y: 16}` to avoid race condition.